### PR TITLE
added `refresh=True` to `progress.update()` for notebook support

### DIFF
--- a/joblib_progress/__init__.py
+++ b/joblib_progress/__init__.py
@@ -35,7 +35,7 @@ def joblib_progress(description: Optional[str] = None, total: Optional[int] = No
 
     class BatchCompletionCallback(joblib.parallel.BatchCompletionCallBack):
         def __call__(self, *args, **kwargs):
-            progress.update(task_id, advance=self.batch_size)
+            progress.update(task_id, advance=self.batch_size, refresh=True)
             return super().__call__(*args, **kwargs)
 
     old_callback = joblib.parallel.BatchCompletionCallBack


### PR DESCRIPTION
This PR allows the progress bar to reach 100% when run within a Jupyter(Lab) notebook cell while keeping the script functionality in tact. 